### PR TITLE
Fix Bug on Data Type BigInt and Decimal

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,6 +23,8 @@ model User {
   posts       Post[]
   keywords    String[]
   biography   Json
+  decimal     Decimal
+  biginteger  BigInt
 }
 
 model Post {

--- a/prisma/typebox/Post.ts
+++ b/prisma/typebox/Post.ts
@@ -3,7 +3,7 @@ import { Role } from "./Role";
 
 export const Post = Type.Object({
   id: Type.Number(),
-  user: Type.Partial(
+  user: Type.Optional(
     Type.Object({
       id: Type.Number(),
       createdAt: Type.Optional(Type.String()),

--- a/prisma/typebox/Post.ts
+++ b/prisma/typebox/Post.ts
@@ -3,7 +3,7 @@ import { Role } from "./Role";
 
 export const Post = Type.Object({
   id: Type.Number(),
-  user: Type.Optional(
+  user: Type.Partial(
     Type.Object({
       id: Type.Number(),
       createdAt: Type.Optional(Type.String()),

--- a/prisma/typebox/Post.ts
+++ b/prisma/typebox/Post.ts
@@ -15,6 +15,8 @@ export const Post = Type.Object({
       role: Type.Optional(Role),
       keywords: Type.Array(Type.String()),
       biography: Type.String(),
+      decimal: Type.Number(),
+      biginteger: Type.Integer(),
     })
   ),
   userId: Type.Optional(Type.Number()),

--- a/prisma/typebox/PostInput.ts
+++ b/prisma/typebox/PostInput.ts
@@ -3,7 +3,7 @@ import { Role } from "./Role";
 
 export const PostInput = Type.Object({
   id: Type.Optional(Type.Number()),
-  user: Type.Partial(
+  user: Type.Optional(
     Type.Object({
       id: Type.Optional(Type.Number()),
       createdAt: Type.Optional(Type.String()),

--- a/prisma/typebox/PostInput.ts
+++ b/prisma/typebox/PostInput.ts
@@ -15,6 +15,8 @@ export const PostInput = Type.Object({
       role: Type.Optional(Role),
       keywords: Type.Array(Type.String()),
       biography: Type.String(),
+      decimal: Type.Number(),
+      biginteger: Type.Integer(),
     })
   ),
   userId: Type.Optional(Type.Number()),

--- a/prisma/typebox/PostInput.ts
+++ b/prisma/typebox/PostInput.ts
@@ -3,7 +3,7 @@ import { Role } from "./Role";
 
 export const PostInput = Type.Object({
   id: Type.Optional(Type.Number()),
-  user: Type.Optional(
+  user: Type.Partial(
     Type.Object({
       id: Type.Optional(Type.Number()),
       createdAt: Type.Optional(Type.String()),

--- a/prisma/typebox/User.ts
+++ b/prisma/typebox/User.ts
@@ -18,6 +18,8 @@ export const User = Type.Object({
   ),
   keywords: Type.Array(Type.String()),
   biography: Type.String(),
+  decimal: Type.Number(),
+  biginteger: Type.Integer(),
 });
 
 export type UserType = Static<typeof User>;

--- a/prisma/typebox/UserInput.ts
+++ b/prisma/typebox/UserInput.ts
@@ -18,6 +18,8 @@ export const UserInput = Type.Object({
   ),
   keywords: Type.Array(Type.String()),
   biography: Type.String(),
+  decimal: Type.Number(),
+  biginteger: Type.Integer(),
 });
 
 export type UserInputType = Static<typeof UserInput>;

--- a/src/generator/transformDMMF.ts
+++ b/src/generator/transformDMMF.ts
@@ -32,17 +32,10 @@ const transformField = (field: DMMF.Field) => {
   }
 
   if ((!field.isRequired || field.hasDefaultValue) && !field.isId) {
-    if (field.kind !== 'object') {
-      tokens.splice(1, 0, 'Type.Optional(');
-      tokens.splice(tokens.length, 0, ')');
-      inputTokens.splice(1, 0, 'Type.Optional(');
-      inputTokens.splice(inputTokens.length, 0, ')');
-    } else {
-      tokens.splice(1, 0, 'Type.Partial(');
-      tokens.splice(tokens.length, 0, ')');
-      inputTokens.splice(1, 0, 'Type.Partial(');
-      inputTokens.splice(inputTokens.length, 0, ')');
-    }
+    tokens.splice(1, 0, 'Type.Optional(');
+    tokens.splice(tokens.length, 0, ')');
+    inputTokens.splice(1, 0, 'Type.Optional(');
+    inputTokens.splice(inputTokens.length, 0, ')');
   }
 
   return {

--- a/src/generator/transformDMMF.ts
+++ b/src/generator/transformDMMF.ts
@@ -5,8 +5,10 @@ const transformField = (field: DMMF.Field) => {
   let inputTokens = [];
   const deps = new Set();
 
-  if (['Int', 'Float'].includes(field.type)) {
+  if (['Int', 'Float', 'Decimal'].includes(field.type)) {
     tokens.push('Type.Number()');
+  } else if (['BigInt'].includes(field.type)) {
+    tokens.push('Type.Integer()');
   } else if (['String', 'DateTime', 'Json', 'Date'].includes(field.type)) {
     tokens.push('Type.String()');
   } else if (field.type === 'Boolean') {

--- a/src/generator/transformDMMF.ts
+++ b/src/generator/transformDMMF.ts
@@ -32,10 +32,17 @@ const transformField = (field: DMMF.Field) => {
   }
 
   if ((!field.isRequired || field.hasDefaultValue) && !field.isId) {
-    tokens.splice(1, 0, 'Type.Optional(');
-    tokens.splice(tokens.length, 0, ')');
-    inputTokens.splice(1, 0, 'Type.Optional(');
-    inputTokens.splice(inputTokens.length, 0, ')');
+    if (field.kind !== 'object') {
+      tokens.splice(1, 0, 'Type.Optional(');
+      tokens.splice(tokens.length, 0, ')');
+      inputTokens.splice(1, 0, 'Type.Optional(');
+      inputTokens.splice(inputTokens.length, 0, ')');
+    } else {
+      tokens.splice(1, 0, 'Type.Partial(');
+      tokens.splice(tokens.length, 0, ')');
+      inputTokens.splice(1, 0, 'Type.Partial(');
+      inputTokens.splice(inputTokens.length, 0, ')');
+    }
   }
 
   return {


### PR DESCRIPTION
Added support of data type `Decimal` and `BigInt` as the package has issue on those 2 data types (#4 and #5).

With this pull request data type `Decimal` will be `Type.Number()` as from the existing code it shows that `Float` (which have the same characteristic) are already translated into `Number` type in typebox as well.  And for BigInt I think it is most accurately shown as `Type.Integer()` even though it is not exactly `BigInt` but that's what typebox has to offer.

This pull request should close #4, close #5, close #7.