### PR TITLE
fix: @id always optional for default values

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,8 +28,8 @@ model User {
 }
 
 model Post {
-  id     Int   @id @default(autoincrement())
-  user   User? @relation(fields: [userId], references: [id])
+  id     String @id @default(cuid())
+  user   User?  @relation(fields: [userId], references: [id])
   userId Int?
 }
 

--- a/prisma/typebox/Post.ts
+++ b/prisma/typebox/Post.ts
@@ -2,7 +2,7 @@ import { Type, Static } from "@sinclair/typebox";
 import { Role } from "./Role";
 
 export const Post = Type.Object({
-  id: Type.Number(),
+  id: Type.String(),
   user: Type.Optional(
     Type.Object({
       id: Type.Number(),

--- a/prisma/typebox/PostInput.ts
+++ b/prisma/typebox/PostInput.ts
@@ -2,7 +2,7 @@ import { Type, Static } from "@sinclair/typebox";
 import { Role } from "./Role";
 
 export const PostInput = Type.Object({
-  id: Type.Optional(Type.Number()),
+  id: Type.Optional(Type.String()),
   user: Type.Optional(
     Type.Object({
       id: Type.Optional(Type.Number()),

--- a/prisma/typebox/User.ts
+++ b/prisma/typebox/User.ts
@@ -12,7 +12,7 @@ export const User = Type.Object({
   role: Type.Optional(Role),
   posts: Type.Array(
     Type.Object({
-      id: Type.Number(),
+      id: Type.String(),
       userId: Type.Optional(Type.Number()),
     })
   ),

--- a/prisma/typebox/UserInput.ts
+++ b/prisma/typebox/UserInput.ts
@@ -12,7 +12,7 @@ export const UserInput = Type.Object({
   role: Type.Optional(Role),
   posts: Type.Array(
     Type.Object({
-      id: Type.Optional(Type.Number()),
+      id: Type.Optional(Type.String()),
       userId: Type.Optional(Type.Number()),
     })
   ),

--- a/prisma/typebox/index.ts
+++ b/prisma/typebox/index.ts
@@ -1,0 +1,5 @@
+export * from './User';
+export * from './Post';
+export * from './UserInput';
+export * from './Role';
+export * from './PostInput';

--- a/src/generator/transformDMMF.ts
+++ b/src/generator/transformDMMF.ts
@@ -25,8 +25,8 @@ const transformField = (field: DMMF.Field) => {
 
   inputTokens = [...tokens];
 
-  // @id cannot be optional except for input if it's auto increment
-  if (field.isId && (field?.default as any)?.name === 'autoincrement') {
+  // @id can be optional for input value if it has a default defined
+  if (field.isId && (field?.default as any)) {
     inputTokens.splice(1, 0, 'Type.Optional(');
     inputTokens.splice(inputTokens.length, 0, ')');
   }


### PR DESCRIPTION
@id field will only be optional for `Int` fields with `autoincrement()` which results in any other @id field with default to not be optional in the input value.

This doesn't really make any sense as if there's *any* `@default` value, the `@id` field should *always* be optional for the input type.