### PR TITLE
fix: use null type instead of optional for generated type

### DIFF
--- a/prisma/typebox/Post.ts
+++ b/prisma/typebox/Post.ts
@@ -2,7 +2,7 @@ import { Type, Static } from "@sinclair/typebox";
 
 export const Post = Type.Object({
   id: Type.Number(),
-  userId: Type.Optional(Type.Number()),
+  userId: Type.Union([Type.Number(), Type.Null()]),
 });
 
 export type PostType = Static<typeof Post>;

--- a/prisma/typebox/User.ts
+++ b/prisma/typebox/User.ts
@@ -4,17 +4,17 @@ import { Role } from "./Role";
 export const User = Type.Object(
   {
     id: Type.Number(),
-    createdAt: Type.Optional(Type.String()),
+    createdAt: Type.Union([Type.String(), Type.Null()]),
     email: Type.String(),
-    weight: Type.Optional(Type.Number()),
-    is18: Type.Optional(Type.Boolean()),
-    name: Type.Optional(Type.String()),
-    successorId: Type.Optional(Type.Number()),
-    role: Type.Optional(Role),
+    weight: Type.Union([Type.Number(), Type.Null()]),
+    is18: Type.Union([Type.Boolean(), Type.Null()]),
+    name: Type.Union([Type.String(), Type.Null()]),
+    successorId: Type.Union([Type.Number(), Type.Null()]),
+    role: Type.Union([Role, Type.Null()]),
     posts: Type.Array(
       Type.Object({
         id: Type.Number(),
-        userId: Type.Optional(Type.Number()),
+        userId: Type.Union([Type.Number(), Type.Null()]),
       })
     ),
     keywords: Type.Array(Type.String({ minLength: 3 }), { maxItems: 10 }),

--- a/src/generator/transformDMMF.ts
+++ b/src/generator/transformDMMF.ts
@@ -88,8 +88,8 @@ export function createTransformer(generatorName: string) {
     }
 
     if ((!field.isRequired || field.hasDefaultValue) && !field.isId) {
-      tokens.splice(1, 0, 'Type.Optional(');
-      tokens.splice(tokens.length, 0, ')');
+      tokens.splice(1, 0, 'Type.Union([');
+      tokens.splice(tokens.length, 0, ',Type.Null()])');
       inputTokens.splice(1, 0, 'Type.Optional(');
       inputTokens.splice(inputTokens.length, 0, ')');
     }


### PR DESCRIPTION
When dealing with optional data prisma generates the type as null or the desired type.
Currently the generator makes it undefined or the desired type.

For example the prisma generated type for the Post model is currently
```
export type Post = {
  id: number
  userId: number | null
}
```

however the generator creates the type as:
```
export const Post = Type.Object({
  id: Type.Number(),
  userId: Type.Optional(Type.Number()),
});
``` 
which is the same as number | undefined 

Fixes: #19